### PR TITLE
fix(rockspec): development branch is main, not master

### DIFF
--- a/mimetypes-dev-1.rockspec
+++ b/mimetypes-dev-1.rockspec
@@ -10,7 +10,7 @@ version = package_version.."-"..rockspec_revision
 
 source = {
   url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
-  branch = (package_version == "dev") and "master" or nil,
+  branch = (package_version == "dev") and "main" or nil,
   tag = (package_version ~= "dev") and package_version or nil,
 }
 


### PR DESCRIPTION
due to age I assumed this lib had `master` as development branch, but it was `main`. Changed it back.